### PR TITLE
Get 5 related posts on blog

### DIFF
--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -10,6 +10,11 @@ module Api
         @post = Post.find(params[:id])
         render json: PostSerializer.new(@post)
       end
+
+      def related_posts
+        @posts = Post.where('id > ?', params[:id]).order(id: :desc).last(4) + [Post.where('id < ?', params[:id]).order(id: :desc).first]
+        render json: PostSerializer.new(@posts)
+      end
     end
   end
 end

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -20,13 +20,19 @@
 #
 class PostSerializer
   include FastJsonapi::ObjectSerializer
+
   set_type :post
+
   attributes  :title,
               :source,
               :post_type,
-              :created_at
+              :created_at,
+              :updated_at,
+              :slug
+
   attributes  :image do |post|
     post.image.url
   end
+
   attributes :content, &:serializable_rich_content
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,11 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :posts, only: %i[index show]
+      resources :posts, only: %i[index show] do
+        member do
+          get :related_posts
+        end
+      end
       resources :careers, only: %i[index show]
       resources :job_submissions
       resources :subscriptions


### PR DESCRIPTION
### ISSUE 
- Link to issue: https://trello.com/c/59zOjc9i/446-blog-page-api-return-related-blogs-url-alongside-the-selected-blog-details#

### Improve / Changes 
- Write function get 5 lastest posts
- Edit post serializer
- Return json
- Edit routes

### Screenshots 

<img width="1028" alt="image" src="https://user-images.githubusercontent.com/62228122/87758803-58651f00-c837-11ea-9f28-fae7fa262915.png">
<img width="1082" alt="image" src="https://user-images.githubusercontent.com/62228122/87758825-61ee8700-c837-11ea-8af6-0739b6214ccb.png">


